### PR TITLE
Use stronger random generator when possible

### DIFF
--- a/src/oauth2_token.erl
+++ b/src/oauth2_token.erl
@@ -33,6 +33,11 @@
          generate/0
         ]).
 
+%%% Exported for testability
+-export([
+         strong_rand_bytes_proxy/1
+        ]).
+
 %%%===================================================================
 %%% API functions
 %%%===================================================================
@@ -50,7 +55,7 @@ generate() ->
 generate_fragment(0) ->
     <<>>;
 generate_fragment(N) ->
-    Rand = base64:encode(crypto:strong_rand_bytes(N)),
+    Rand = base64:encode(rand_bytes(N)),
     Frag = << <<C>> || <<C>> <= <<Rand:N/bytes>>, is_alphanum(C) >>,
     <<Frag/binary, (generate_fragment(N - byte_size(Frag)))/binary>>.
 
@@ -64,3 +69,23 @@ is_alphanum(C) when C >= 16#61 andalso C =< 16#7A ->
     true;
 is_alphanum(_) ->
     false.
+
+%% @doc Generate N random bytes, using the crypto:strong_rand_bytes
+%% function if sufficient entropy exists. If not, use crypto:rand_bytes
+%% as a fallback.
+-spec rand_bytes(N :: non_neg_integer()) -> binary().
+rand_bytes(N) ->
+    try
+        %% NOTE: Apparently we can't meck away the crypto module,
+        %% so we install this proxy to allow for testing the low_entropy
+        %% situation.
+        ?MODULE:strong_rand_bytes_proxy(N)
+    catch
+        throw:low_entropy ->
+            crypto:rand_bytes(N)
+    end.
+
+%% @equiv crypto:strong_rand_bytes(N)
+-spec strong_rand_bytes_proxy(N :: non_neg_integer()) -> binary().
+strong_rand_bytes_proxy(N) ->
+    crypto:strong_rand_bytes(N).

--- a/test/oauth2_token_tests.erl
+++ b/test/oauth2_token_tests.erl
@@ -38,6 +38,28 @@ generate_test() ->
     ?assertEqual(byte_size(Token), ?TOKEN_LENGTH),
     ?assert(lists:all(fun is_alphanum/1, binary_to_list(Token))).
 
+generate_low_entropy_test_() ->
+    {setup,
+     fun() ->
+             meck:new(oauth2_token, [passthrough]),
+             meck:expect(oauth2_token, strong_rand_bytes_proxy,
+                         fun(_) -> throw(low_entropy) end)
+     end,
+     fun(_) ->
+             meck:unload(oauth2_token)
+     end,
+     fun(_) ->
+             [
+              ?_assertEqual(
+                 byte_size(oauth2_token:generate()),
+                 ?TOKEN_LENGTH),
+              ?_assert(
+                 lists:all(fun is_alphanum/1,
+                           binary_to_list(
+                             oauth2_token:generate())))
+             ]
+     end}.
+
 %%%===================================================================
 %%% Utility functions
 %%%===================================================================


### PR DESCRIPTION
These two commits switch from using the `crypto:rand_bytes` function to using the stronger `crypto:strong_rand_bytes` when possible. The latter may throw `low_entropy`; this potential problem is handled by falling back on the weaker sibling if necessary.
