### PR TITLE
Added issue_code_grant/3 and issue_code_grant/4

### DIFF
--- a/rebar.tests.config
+++ b/rebar.tests.config
@@ -38,7 +38,7 @@
     warn_obsolete_guard,
     %% warn_unused_import,
     warn_bif_clash,
-    %% warnings_as_errors,
+    warnings_as_errors,
     %% warn_missing_spec,
     warn_untyped_record,
     debug_info

--- a/src/oauth2.erl
+++ b/src/oauth2.erl
@@ -98,7 +98,7 @@ issue_code_grant(ClientId, ResOwner, Scope) ->
             Response = issue_code(Identity, Scope, ResOwner, TTL),
             {ok, Identity, Response};
         {error, _Reason} ->
-            {error, unauthorized_client}
+            {error, invalid_client}
     end.
 
 %% @doc Issue a Code via Access Code Grant
@@ -123,7 +123,7 @@ issue_code_grant(ClientId, RedirectionUri, ResOwner, Scope) ->
                     {error, access_denied}
             end;
         {error, _Reason} ->
-            {error, unauthorized_client}
+            {error, invalid_client}
     end.
 
 %% @doc Issue a Code via Access Code Grant.

--- a/src/oauth2_backend.erl
+++ b/src/oauth2_backend.erl
@@ -40,6 +40,7 @@
          ,revoke_access_code/1
          ,revoke_refresh_token/1
          ,get_redirection_uri/1
+         ,get_client_identity/2
         ]).
 
 -type proplist(Key, Val) :: [{Key, Val}].


### PR DESCRIPTION
- Added oauth2:issue_code_grant/3 and oauth2:issue_code_grant/4 because the protocol doesn't do client validation at this step and doesn't require a redirect_uri parameter (See point 4.1.1 in the specification). 
- Added oauth2_backend:get_client_identity/2 to allow getting the client identity without validating the password.
- Added tests for the new issue_code_grant functions.
  I'm not sure issue_code_grant/5 is of any issue, but I didn't remove it.
