### PR TITLE
Added oauth2_response:token_type/1

### DIFF
--- a/src/oauth2_response.erl
+++ b/src/oauth2_response.erl
@@ -28,6 +28,7 @@
 
 %% Length of binary data to use for token generation.
 -define(TOKEN_LENGTH, 32).
+-define(TOKEN_TYPE, <<"bearer">>).
 
 %%% API
 -export([
@@ -48,6 +49,7 @@
          ,expires_in/2
          ,scope/1
          ,scope/2
+         ,token_type/1
          ,to_proplist/1
         ]).
 
@@ -58,7 +60,7 @@
           ,resource_owner :: term()
           ,scope          :: oauth2:scope()
           ,refresh_token  :: oauth2:token()
-          ,token_type = <<"bearer">> :: binary()
+          ,token_type = ?TOKEN_TYPE :: binary()
          }).
 
 -type response() :: #response{}.
@@ -186,6 +188,10 @@ resource_owner(#response{resource_owner = ResOwner}) ->
     NewResOwner :: term().
 resource_owner(Response, NewResOwner) ->
     Response#response{resource_owner = NewResOwner}.
+
+-spec token_type(response()) -> {ok, binary()}.
+token_type(#response{}) ->
+    {ok, ?TOKEN_TYPE}.
 
 -spec to_proplist(response()) -> oauth2:proplist(binary(), binary()).
 to_proplist(Response) ->

--- a/test/oauth2_response_tests.erl
+++ b/test/oauth2_response_tests.erl
@@ -35,6 +35,8 @@
 -define(RESOURCE_OWNER, <<"user">>).
 -define(EXPIRY,  3600).
 -define(SCOPE,   <<"herp derp">>).
+-define(TOKEN_TYPE, <<"bearer">>).
+
 
 %%%===================================================================
 %%% Test cases
@@ -154,6 +156,10 @@ resource_owner_test() ->
                    oauth2_response:resource_owner(
                      oauth2_response:new(?ACCESS),
                      ?RESOURCE_OWNER))).
+
+token_type_test() ->
+    ?assertEqual({ok, ?TOKEN_TYPE},
+                 oauth2_response:token_type(oauth2_response:new(?ACCESS))).
 
 to_proplist_test() ->
     Response = oauth2_response:new(?ACCESS, ?EXPIRY, ?RESOURCE_OWNER, ?SCOPE, ?REFRESH),


### PR DESCRIPTION
The oauth2_response:response record has a token_type field, but there is no function to read its value. Such function is needed to get the value of the token_type parameter for the response of authorization requests, see point 5.1 in the specification.
