### PR TITLE
Replaced existing oauth2:issue_code_grant functions

### DIFF
--- a/src/oauth2.erl
+++ b/src/oauth2.erl
@@ -31,8 +31,6 @@
          authorize_password/3
          ,authorize_client_credentials/3
          ,authorize_code_grant/4
-         ,issue_code_grant/3
-         ,issue_code_grant/4
          ,issue_code_grant/5
          ,verify_access_token/1
          ,verify_access_code/1
@@ -90,70 +88,39 @@ authorize_password(Username, Password, Scope) ->
     end.
 
 %% @doc Issue a Code via Access Code Grant
--spec issue_code_grant(ClientId, ResOwner, Scope)
+-spec issue_code_grant(ClientId, RedirectionUri, Username, Password, Scope)
                        -> {ok, Identity, Response} | {error, Reason} when
-      ClientId       :: binary(),
-      ResOwner       :: term(),
-      Scope          :: scope(),
-      Identity       :: term(),
-      Response       :: oauth2_response:response(),
-      Reason         :: error().
-issue_code_grant(ClientId, ResOwner, Scope) ->
-    case ?BACKEND:get_client_identity(ClientId) of
-        {ok, Identity} ->
-            TTL = oauth2_config:expiry_time(code_grant),
-            Response = issue_code(Identity, Scope, ResOwner, TTL),
-            {ok, Identity, Response};
-        {error, _Reason} ->
-            {error, invalid_client}
-    end.
-
-%% @doc Issue a Code via Access Code Grant
--spec issue_code_grant(ClientId, RedirectionUri, ResOwner, Scope)
-                       -> {ok, Identity, Response} | {error, Reason} when
-      ClientId       :: binary(),
-      RedirectionUri :: scope(),
-      ResOwner       :: term(),
-      Scope          :: scope(),
-      Identity       :: term(),
-      Response       :: oauth2_response:response(),
-      Reason         :: error().
-issue_code_grant(ClientId, RedirectionUri, ResOwner, Scope) ->
+      ClientId          :: binary(),
+      RedirectionUri    :: scope(),
+      Username          :: binary(),
+      Password          :: binary(),
+      Scope             :: scope(),
+      Identity          :: term(),
+      Response          :: oauth2_response:response(),
+      Reason            :: error().
+issue_code_grant(ClientId, RedirectionUri, Username, Password, Scope) ->
     case ?BACKEND:get_client_identity(ClientId) of
         {ok, Identity} ->
             case ?BACKEND:verify_redirection_uri(Identity, RedirectionUri) of
                 ok ->
-                    TTL = oauth2_config:expiry_time(code_grant),
-                    Response = issue_code(Identity, Scope, ResOwner, TTL),
-                    {ok, Identity, Response};
+                    case ?BACKEND:verify_client_scope(Identity, Scope) of
+                        {ok, VerifiedScope} ->
+                            case ?BACKEND:authenticate_username_password(
+                                   Username, Password) of
+                                {ok, ResOwner} ->
+                                    TTL = oauth2_config:expiry_time(code_grant),
+                                    Response = issue_code(Identity, 
+                                                          VerifiedScope, 
+                                                          ResOwner, TTL),
+                                    {ok, Identity, Response};
+                                {error, _Reason} ->
+                                    {error, access_denied}
+                            end;
+                        {error, _Reason} ->
+                            {error, invalid_scope}
+                    end;
                 _ ->
-                    {error, access_denied}
-            end;
-        {error, _Reason} ->
-            {error, invalid_client}
-    end.
-
-%% @doc Issue a Code via Access Code Grant.
--spec issue_code_grant(ClientId, ClientSecret, RedirectionUri, ResOwner, Scope)
-                       -> {ok, Identity, Response} | {error, Reason} when
-      ClientId       :: binary(),
-      ClientSecret   :: binary(),
-      RedirectionUri :: scope(),
-      ResOwner       :: term(),
-      Scope          :: scope(),
-      Identity       :: term(),
-      Response       :: oauth2_response:response(),
-      Reason         :: error().
-issue_code_grant(ClientId, ClientSecret, RedirectionUri, ResOwner, Scope) ->
-    case ?BACKEND:authenticate_client(ClientId, ClientSecret) of
-        {ok, Identity} ->
-            case ?BACKEND:verify_redirection_uri(Identity, RedirectionUri) of
-                ok ->
-                    TTL = oauth2_config:expiry_time(code_grant),
-                    Response = issue_code(Identity, Scope, ResOwner, TTL),
-                    {ok, Identity, Response};
-                _ ->
-                    {error, access_denied}
+                    {error, unauthorized_client}
             end;
         {error, _Reason} ->
             {error, unauthorized_client}

--- a/test/oauth2_tests.erl
+++ b/test/oauth2_tests.erl
@@ -182,57 +182,35 @@ bad_access_code_test_() ->
      fun(_) ->
              [
               fun() ->
-                      {error, access_denied} = oauth2:issue_code_grant(
+                      {error, unauthorized_client} = oauth2:issue_code_grant(
                                          ?CLIENT_ID,
-                                         ?CLIENT_SECRET,
                                          <<"http://in.val.id">>,
-                                         ?RESOURCE_OWNER,
+                                         ?USER_NAME,
+                                         ?USER_PASSWORD,
                                          ?CLIENT_SCOPE),
                       {error, unauthorized_client} = oauth2:issue_code_grant(
                                          <<"XoaUdYODRCMyLkdaKkqlmhsl9QQJ4b">>,
-                                         ?CLIENT_SECRET,
                                          ?CLIENT_URI,
-                                         ?RESOURCE_OWNER,
+                                         ?USER_NAME,
+                                         ?USER_PASSWORD,
                                          ?CLIENT_SCOPE),
-                      ?_assertMatch({error, invalid_grant},
-                                    oauth2:verify_access_code(<<"nonexistent_token">>))
-              end
-             ]
-     end}.
-
-bad_access_code_icg3_test_() ->
-    {setup,
-     fun start/0,
-     fun stop/1,
-     fun(_) ->
-             [
-              fun() ->
-                      {error, invalid_client} = oauth2:issue_code_grant(
-                                         <<"XoaUdYODRCMyLkdaKkqlmhsl9QQJ4b">>,
-                                         ?RESOURCE_OWNER,
-                                         ?CLIENT_SCOPE),
-                      ?_assertMatch({error, invalid_grant},
-                                    oauth2:verify_access_code(<<"nonexistent_token">>))
-              end
-             ]
-     end}.
-
-bad_access_code_icg4_test_() ->
-    {setup,
-     fun start/0,
-     fun stop/1,
-     fun(_) ->
-             [
-              fun() ->
+                      {error, invalid_scope} = oauth2:issue_code_grant(
+                                         ?CLIENT_ID,
+                                         ?CLIENT_URI,
+                                         ?USER_NAME,
+                                         ?USER_PASSWORD,
+                                         <<"bad_scope">>),
                       {error, access_denied} = oauth2:issue_code_grant(
                                          ?CLIENT_ID,
-                                         <<"http://in.val.id">>,
-                                         ?RESOURCE_OWNER,
-                                         ?CLIENT_SCOPE),
-                      {error, invalid_client} = oauth2:issue_code_grant(
-                                         <<"XoaUdYODRCMyLkdaKkqlmhsl9QQJ4b">>,
                                          ?CLIENT_URI,
-                                         ?RESOURCE_OWNER,
+                                         <<"herp">>,
+                                         <<"herp">>,
+                                         ?CLIENT_SCOPE),
+                      {error, access_denied} = oauth2:issue_code_grant(
+                                         ?CLIENT_ID,
+                                         ?CLIENT_URI,
+                                         <<"derp">>,
+                                         <<"derp">>,
                                          ?CLIENT_SCOPE),
                       ?_assertMatch({error, invalid_grant},
                                     oauth2:verify_access_code(<<"nonexistent_token">>))
@@ -249,65 +227,12 @@ verify_access_code_test_() ->
               fun() ->
                       {ok, _, Response} = oauth2:issue_code_grant(
                                          ?CLIENT_ID,
-                                         ?CLIENT_SECRET,
                                          ?CLIENT_URI,
-                                         ?RESOURCE_OWNER,
+                                         ?USER_NAME,
+                                         ?USER_PASSWORD,
                                          ?CLIENT_SCOPE),
                       {ok, Code} = oauth2_response:access_code(Response),
-                      ?assertMatch({ok, ?RESOURCE_OWNER},
-                                   oauth2_response:resource_owner(Response)),
-                      ?assertMatch({ok, _}, oauth2:verify_access_code(Code)),
-                      {ok, _, Response2} = oauth2:authorize_code_grant(
-                                         ?CLIENT_ID,
-                                         ?CLIENT_SECRET,
-                                         Code,
-                                         ?CLIENT_URI),
-                      {ok, Token} = oauth2_response:access_token(Response2),
-                      ?assertMatch({ok, _}, oauth2:verify_access_token(Token))
-              end
-             ]
-     end}.
-
-verify_access_code_icg3_test_() ->
-    {setup,
-     fun start/0,
-     fun stop/1,
-     fun(_) ->
-             [
-              fun() ->
-                      {ok, _, Response} = oauth2:issue_code_grant(
-                                         ?CLIENT_ID,
-                                         ?RESOURCE_OWNER,
-                                         ?CLIENT_SCOPE),
-                      {ok, Code} = oauth2_response:access_code(Response),
-                      ?assertMatch({ok, ?RESOURCE_OWNER},
-                                   oauth2_response:resource_owner(Response)),
-                      ?assertMatch({ok, _}, oauth2:verify_access_code(Code)),
-                      {ok, _, Response2} = oauth2:authorize_code_grant(
-                                         ?CLIENT_ID,
-                                         ?CLIENT_SECRET,
-                                         Code,
-                                         ?CLIENT_URI),
-                      {ok, Token} = oauth2_response:access_token(Response2),
-                      ?assertMatch({ok, _}, oauth2:verify_access_token(Token))
-              end
-             ]
-     end}.
-
-verify_access_code_icg4_test_() ->
-    {setup,
-     fun start/0,
-     fun stop/1,
-     fun(_) ->
-             [
-              fun() ->
-                      {ok, _, Response} = oauth2:issue_code_grant(
-                                         ?CLIENT_ID,
-                                         ?CLIENT_URI,
-                                         ?RESOURCE_OWNER,
-                                         ?CLIENT_SCOPE),
-                      {ok, Code} = oauth2_response:access_code(Response),
-                      ?assertMatch({ok, ?RESOURCE_OWNER},
+                      ?assertMatch({ok, {user, 31337}},
                                    oauth2_response:resource_owner(Response)),
                       ?assertMatch({ok, _}, oauth2:verify_access_code(Code)),
                       {ok, _, Response2} = oauth2:authorize_code_grant(
@@ -330,9 +255,9 @@ verify_refresh_token_test_() ->
               fun() ->
                       {ok, _, Response} = oauth2:issue_code_grant(
                                          ?CLIENT_ID,
-                                         ?CLIENT_SECRET,
                                          ?CLIENT_URI,
-                                         ?RESOURCE_OWNER,
+                                         ?USER_NAME,
+                                         ?USER_PASSWORD,
                                          ?CLIENT_SCOPE),
                       {ok, Code} = oauth2_response:access_code(Response),
                       {ok, _, Response2} = oauth2:authorize_code_grant(


### PR DESCRIPTION
After finishing my implementation of the Authorization Code Grant flow, I came to the conclusion that none of the existing oauth2:issue_code_grant functions is really helpful. None of them verifies the resource owner's username or password, nor the scope. issue_code_grant/5 doesn't comply with the specification because it expects a client secret that is not in the request. See http://tools.ietf.org/html/rfc6749#section-4.1.1.
