### PR TITLE
Separated token issuing from request authorization. Renamed issue_code_grant to authorize_code_request. Renamed Identity to Client or ResOwner depending on the case.

### DIFF
--- a/src/oauth2.erl
+++ b/src/oauth2.erl
@@ -44,9 +44,9 @@
 -type token()    :: binary().
 -type lifetime() :: non_neg_integer().
 -type scope()    :: list(binary()) | binary().
--type error()    :: invalid_request | unauthorized_client
-                  | access_denied | unsupported_response_type
-                  | invalid_scope | server_error
+-type error()    :: access_denied | invalid_client | invalid_request 
+                  | invalid_scope | unauthorized_client
+                  | unsupported_response_type | server_error
                   | temporarily_unavailable.
 
 -export_type([
@@ -121,7 +121,7 @@ authorize_client_credentials(ClientId, ClientSecret, Scope) ->
                     {error, invalid_scope}
             end;
         {error, _Reason} ->
-            {error, unauthorized_client}
+            {error, invalid_client}
     end.
 
 %% @doc Authorize client via its own credentials, i.e., a combination
@@ -164,7 +164,7 @@ authorize_code_grant(ClientId, ClientSecret, AccessCode, RedirectionUri) ->
                     {error, invalid_grant}
             end;
         {error, _Reason} ->
-            {error, unauthorized_client}
+            {error, invalid_client}
     end.
 
 %% @doc Issue a Code via Access Code Grant
@@ -204,7 +204,7 @@ authorize_code_request(ClientId, RedirectionUri, Username, Password, Scope) ->
                     {error, unauthorized_client}
             end;
         {error, _Reason} ->
-            {error, unauthorized_client}
+            {error, invalid_client}
     end.
 
 -spec issue_code(Authorization) -> Response when

--- a/test/oauth2_tests.erl
+++ b/test/oauth2_tests.erl
@@ -84,7 +84,7 @@ bad_authorize_client_credentials_test_() ->
         fun stop/1,
         fun(_) ->
                 [
-                 ?_assertMatch({error, unauthorized_client},
+                 ?_assertMatch({error, invalid_client},
                                oauth2:authorize_client_credentials(
                                  <<"XoaUdYODRCMyLkdaKkqlmhsl9QQJ4b">>,
                                  <<"fvfDMAwjlruC9rv5FsLjmyrihCcIKJL">>,
@@ -94,12 +94,12 @@ bad_authorize_client_credentials_test_() ->
                                  ?CLIENT_ID,
                                  ?CLIENT_SECRET,
                                  <<"bad_scope">>)),
-                 ?_assertMatch({error, unauthorized_client},
+                 ?_assertMatch({error, invalid_client},
                                oauth2:authorize_client_credentials(
                                  <<"TiaUdYODLOMyLkdaKkqlmdhsl9QJ94a">>,
                                  <<"gggDMAwklAKc9kq5FsLjKrzihCcI123">>,
                                  <<"abc">>)),
-                 ?_assertMatch({error, unauthorized_client},
+                 ?_assertMatch({error, invalid_client},
                                 oauth2:authorize_client_credentials(
                                  <<"TiaUdYODLOMyLkdaKkqlmdhsl9QJ94a">>,
                                  <<"fvfDMAwjlruC9rv5FsLjmyrihCcIKJL">>,
@@ -190,7 +190,7 @@ bad_access_code_test_() ->
                                          ?USER_NAME,
                                          ?USER_PASSWORD,
                                          ?CLIENT_SCOPE),
-                      {error, unauthorized_client} = 
+                      {error, invalid_client} = 
                           oauth2:authorize_code_request(
                                          <<"XoaUdYODRCMyLkdaKkqlmhsl9QQJ4b">>,
                                          ?CLIENT_URI,


### PR DESCRIPTION
**Changes the library API, breaks the compatibility with any code using the library**
- Authorizing requests and issuing codes or tokens are now performed by different functions, so issuing must be done explicitly. This allows to choose wether to issue a refresh token or not.
- issue_code_grant is renamed to authorize_code_request because the function doesn't issue a code grant anymore, that also must be done explicitly.
- "Identity" variables are renamed to Client or ResOwner to make it clear wether they contain a client identity or a resource owner identity.
