### PR TITLE
Allow authorization with a previously authenticated resource owner

### DIFF
--- a/test/oauth2_tests.erl
+++ b/test/oauth2_tests.erl
@@ -76,6 +76,25 @@ bad_authorize_password_test_() ->
                 ]
         end}.
 
+authorize_resource_owner_test_() ->
+    {setup,
+        fun start/0,
+        fun stop/1,
+        fun(_) ->
+                [
+                 ?_assertMatch({ok, _},
+                               oauth2:authorize_resource_owner(
+                                 {user, 31337},
+                                 [<<"xyz">>],
+                                 foo_context)),
+                 ?_assertMatch({error, invalid_scope},
+                               oauth2:authorize_resource_owner(
+                                 {user, 31337},
+                                 <<"bad_scope">>,
+                                 foo_context))
+                ]
+        end}.
+
 bad_authorize_client_credentials_test_() ->
     {setup,
         fun start/0,


### PR DESCRIPTION
This adds a new function `authorize_resource_owner/3` for establishing
authorization where the resource owner has already been authenticated.
Useful in the case where the Authentication Server is separate to the
Authorization Server.
