### PR TITLE
Add additional oauth2:authorize_password/6 with previous client authentication and fix for #38

### DIFF
--- a/src/oauth2_backend.erl
+++ b/src/oauth2_backend.erl
@@ -25,6 +25,7 @@
 -type appctx()   :: oauth2:appctx().
 -type token()    :: oauth2:token().
 -type scope()    :: oauth2:scope().
+-type client()   :: term().
 
 %%%_* Behaviour ========================================================
 %% @doc Authenticates a combination of username and password.
@@ -34,7 +35,7 @@
 
 %% @doc Authenticates a client's credentials for a given scope.
 -callback authenticate_client(binary(), binary(), appctx()) ->
-                    {ok, {appctx(), term()}} | {error, notfound | badsecret}.
+                    {ok, {appctx(), client()}} | {error, notfound | badsecret}.
 
 %% @doc Stores a new access code token(), associating it with Context.
 %%      The context is a proplist carrying information about the identity
@@ -87,22 +88,22 @@
 
 %% @doc Returns a client identity for a given id.
 -callback get_client_identity(binary(), appctx()) ->
-                    {ok, {appctx(), term()}} | {error, notfound | badsecret}.
+                    {ok, {appctx(), client()}} | {error, notfound | badsecret}.
 
 %% @doc Verifies that RedirectionUri is a valid redirection URI for the
 %%      client identified by Identity.
--callback verify_redirection_uri(term(), binary(), appctx()) ->
+-callback verify_redirection_uri(client(), binary(), appctx()) ->
                                  {ok, appctx()} | {error, notfound | baduri}.
 
 %% @doc Verifies that scope() is a valid scope for the client identified
 %%      by Identity.
--callback verify_client_scope(term(), scope(), appctx()) ->
+-callback verify_client_scope(client(), scope(), appctx()) ->
                     {ok, {appctx(), scope()}} | {error, notfound | badscope}.
 
 %% @doc Verifies that scope() is a valid scope for the resource
 %%      owner identified by Identity.
 -callback verify_resowner_scope(term(), scope(), appctx()) ->
-                    {ok, {appctx(), scope()}} | {error, notfound | badscope}.
+                    {ok, {appctx(), client(), scope()}} | {error, notfound | badscope}.
 
 %% @doc Verifies that scope() is a valid scope of the set of scopes defined
 %%      by Validscope()s.

--- a/test/oauth2_mock_backend.erl
+++ b/test/oauth2_mock_backend.erl
@@ -136,7 +136,7 @@ verify_client_scope(_, _, _) ->
     {error, invalid_scope}.
 
 verify_resowner_scope({user, 31337}, ?USER_SCOPE, AppContext) ->
-    {ok, {AppContext, ?USER_SCOPE}};
+    {ok, {AppContext, {client, 4711}, ?USER_SCOPE}};
 verify_resowner_scope(_, _, _) ->
     {error, invalid_scope}.
 


### PR DESCRIPTION
WARNING: Breaks the compatibility with existing backend implementations

The client can now be authenticated before the resource owner's
credentials. See RFC6749 / Section 4.3.2 for more details.
In addition to AppCtx and Scope, oauth2_backend:verify_resowner_scope/3
now returns the ClientIdentity so that oauth2:authorize_resource_owner/3
can set the client for the #authorization{} record and
oauth2:refresh_access_token/5 can be successfully executed.
