### PR TITLE
Add Erlang/OTP 17.0 to the Travis CI test matrix and update meck dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: erlang
 otp_release:
+  - 17.0
+  - R16B03-1
+  - R16B03
+  - R16B02
+  - R16B01
   - R16B
   - R15B03
   - R15B02

--- a/rebar.test.config
+++ b/rebar.test.config
@@ -26,7 +26,7 @@
 
 {lib_dirs,            ["deps"]}.
 {deps_dir,            ["deps"]}.
-{require_otp_vsn,     "R1[456]"}.
+{require_otp_vsn,     "R1[456]|17"}.
 {erl_opts,            [ debug_info
                       , warn_format
                       , warn_export_all
@@ -51,6 +51,6 @@
 
 
 {deps,
-  [ {meck,   ".*", {git, "https://github.com/eproxus/meck.git",   {tag, "0.8"}}}
+  [ {meck,   ".*", {git, "https://github.com/eproxus/meck.git",   {tag, "0.8.2"}}}
   , {proper, ".*", {git, "git://github.com/manopapad/proper.git", {tag, "v1.1"}}}
   ] }.


### PR DESCRIPTION
Missing Erlang/OTP R16B01 - R16B03-01 are also added to the test matrix.
