### PR TITLE
Fix oauth2_response:to_proplist/1 for correct scoping according to RFC6749 section 3.3

### DIFF
--- a/src/oauth2_response.erl
+++ b/src/oauth2_response.erl
@@ -174,7 +174,7 @@ to_binary(Binary) when is_binary(Binary) ->
 to_binary([Binary]) when is_binary(Binary) ->
     Binary;
 to_binary([BinaryHead | Tail]) when is_binary(BinaryHead) ->
-    <<BinaryHead/binary, <<" ">>/binary, (to_binary(Tail))/binary >>;
+    <<BinaryHead/binary, " ", (to_binary(Tail))/binary>>;
 to_binary(List) when is_list(List) ->
     to_binary(list_to_binary(List));
 to_binary(Atom) when is_atom(Atom) ->

--- a/test/oauth2_response_tests.erl
+++ b/test/oauth2_response_tests.erl
@@ -188,4 +188,4 @@ scope_to_binary([]) ->
 scope_to_binary([Binary]) when is_binary(Binary) ->
     Binary;
 scope_to_binary([BinaryHead | Tail]) when is_binary(BinaryHead) ->
-    <<BinaryHead/binary, <<" ">>/binary, (scope_to_binary(Tail))/binary >>.
+    <<BinaryHead/binary, " ", (scope_to_binary(Tail))/binary>>.


### PR DESCRIPTION
Scopes should be expressed as a list of space-delimited, case-sensitive strings. 

At the moment:

``` erlang
oauth2_response:to_proplist(oauth2_response:new(..., ..., ..., [<<"herp">>, <<"derp">>], ...)).
[...
 {<<"scope">>,<<"herpderp">>},
...
]
```

Should be:

``` erlang
oauth2_response:to_proplist(oauth2_response:new(..., ..., ..., [<<"herp">>, <<"derp">>], ...)).
[...
 {<<"scope">>,<<"herp derp">>},
...
]
```

I've also refactored `oauth2_response_tests:to_proplist_test/0` to a property-based PropEr test, but wasn't sure how to handle the type for `resource_owner::term()` proper. For now i've declared it as `binary()`, since this is the type which `resource_owner` should be converted to.
