### PR TITLE
Hex

### DIFF
--- a/src/oauth2.app.src
+++ b/src/oauth2.app.src
@@ -27,6 +27,7 @@
                   stdlib
                  ]},
   {env, []},
+  {pkg_name, "oauth2_erlang"},
   {maintainers, ["kivra", "Heinz N. Gies"]},
   {licenses,["MIT"]},
   {links,[{"Github",

--- a/src/oauth2.app.src
+++ b/src/oauth2.app.src
@@ -26,5 +26,9 @@
                   kernel,
                   stdlib
                  ]},
-  {env, []}
+  {env, []},
+  {maintainers, ["kivra", "Heinz N. Gies"]},
+  {licenses,["MIT"]},
+  {links,[{"Github",
+           "https://github.com/kivra/oauth2"}]}
  ]}.


### PR DESCRIPTION
Hi I've published oauth2 as a hex package (`oauth2_erlang`), this are the changes necessary to make it hex-able with riak3. Since it is your project it would be great if you'd take over the package, for that you can ask hex.pm to change ownership, until then I'll try to keep it up to date with the latest tagged release.

For the meantime I added myself as a secondary maintainer so that people having questions regarding the package don't bother you, please remove that if you take over the package since I don't want to claim your work as mine.

This would resolve #56 

Cheers,
Heinz

