### PR TITLE
Implicit Grant doesn't need client secret

### DIFF
--- a/test/oauth2_tests.erl
+++ b/test/oauth2_tests.erl
@@ -111,7 +111,7 @@ authorize_implicit_grant_test_() ->
               fun() ->
                       {ok, {foo_context, Auth}} =
                           oauth2:authorize_password( {?USER_NAME,?USER_PASSWORD}
-                                                   , {?CLIENT_ID,?CLIENT_SECRET}
+                                                   , ?CLIENT_ID
                                                    , ?CLIENT_URI
                                                    , ?USER_SCOPE
                                                    , foo_context),


### PR DESCRIPTION
As RFC mentions:

> The implicit grant type does not include client authentication, and
   relies on the presence of the resource owner and the registration of
   the redirection URI.

Client secret is not needed.