### PR TITLE
no-release: Don't blame on recent formatting change

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,3 @@
 # Project-wide erlfmt formatting
 4a9ce4ca05a052a2f81239694ff49b407d29bd8e
+34665ce22d9439993b10bec853680176fe1835ff


### PR DESCRIPTION
## Motivation

Avoid blame on recent un-formatting changes.

## Description

Ease future blaming.

## Further considerations

I ran `git config --global blame.ignoreRevsFile .git-blame-ignore-revs` locally (not sure that that file name is "standard" - but it seems to be widely used -, so I copied it from `kivra-in-a-box`) to always ignore blame in a consistent way.