### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 ---
 name: ci
 permissions:
-  contents: read
+  contents: write
 
 on:
   # for feature branches
@@ -18,9 +18,6 @@ concurrency:
 jobs:
   ci:
     if: github.event_name == 'pull_request'
-    permissions:
-      contents: read
-      pull-requests: write
     name: ci
     runs-on: ubuntu-24.04
 
@@ -71,8 +68,6 @@ jobs:
 
   release:
     if: github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'no-release:') == false
-    permissions:
-      contents: write
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 ---
 name: ci
+permissions:
+  contents: read
 
 on:
   # for feature branches
@@ -16,6 +18,9 @@ concurrency:
 jobs:
   ci:
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
     name: ci
     runs-on: ubuntu-24.04
 
@@ -66,6 +71,8 @@ jobs:
 
   release:
     if: github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'no-release:') == false
+    permissions:
+      contents: write
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Potential fix for [https://github.com/kivra/oauth2/security/code-scanning/1](https://github.com/kivra/oauth2/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. This block will explicitly define the minimal permissions required for the workflow to function correctly. Specifically:
1. At the workflow level, we will set `contents: read` as a baseline permission.
2. For the `ci` job, we will add `contents: read` and `pull-requests: write` since it interacts with pull requests and pushes changes.
3. For the `release` job, we will add `contents: read` and `contents: write` since it creates tags and releases.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
